### PR TITLE
Corrijo un bug al mostrar el título del ejercicio actual cuando se cierra el drawer si este aparecía inicialmente desplegado

### DIFF
--- a/src/es/uniovi/imovil/fcrtrainer/MainActivity.java
+++ b/src/es/uniovi/imovil/fcrtrainer/MainActivity.java
@@ -199,11 +199,11 @@ public class MainActivity extends ActionBarActivity implements
 		};
 
 		// Si el usuario no ha desplegado alguna vez el Drawer
+		mTitle = getString(mExerciseResIndex);
 		if (!mUserLearnedDrawer && !fromSavedState) {
 			mDrawerLayout.openDrawer(mDrawerList);
 			actionBar.setTitle(mDrawerTitle);
-		} else {
-			mTitle = getString(mExerciseResIndex);
+		} else {			
 			setTitle(mTitle);
 		}
 


### PR DESCRIPTION
cierra el drawer si este aparecía inicialmente desplegado
