### PR TITLE
Refactoring: mejores nombres para algunos métodos

### DIFF
--- a/src/es/uniovi/imovil/fcrtrainer/BaseNumericalExerciseFragment.java
+++ b/src/es/uniovi/imovil/fcrtrainer/BaseNumericalExerciseFragment.java
@@ -150,7 +150,7 @@ public abstract class BaseNumericalExerciseFragment extends
 	}
 
 	private void setTitle() {
-		mTitleTextView.setText(getTitleString());
+		mTitleTextView.setText(titleString());
 	}
 
 	private void generateRandomQuestion() {
@@ -188,7 +188,7 @@ public abstract class BaseNumericalExerciseFragment extends
 	}
 
 	private void showSolution() {
-		mAnswerTextView.setText(getSolution());
+		mAnswerTextView.setText(obtainSolution());
 	}
 
 	@Override
@@ -318,7 +318,7 @@ public abstract class BaseNumericalExerciseFragment extends
 
 		try {
 			HighscoreManager.addScore(getActivity().getApplicationContext(),
-					points, getExerciseId(), new Date(), user);
+					points, obtainExerciseId(), new Date(), user);
 		} catch (JSONException e) {
 			Log.v(getClass().getSimpleName(), "Error when saving score");
 		}
@@ -328,7 +328,7 @@ public abstract class BaseNumericalExerciseFragment extends
 	 * Debe retornar la constante usada en FragmentFactory para lanzar el
 	 * fragmento, por ejemplo, R.string.logic_gate
 	 */
-	protected abstract int getExerciseId();
+	protected abstract int obtainExerciseId();
 
 	/**
 	 * Debe retornar true si el resultado está compuesto sólo de números entre 0
@@ -339,7 +339,7 @@ public abstract class BaseNumericalExerciseFragment extends
 	/**
 	 * Debe retornar una cadena con el título del ejercicio actual
 	 */
-	protected abstract String getTitleString();
+	protected abstract String titleString();
 
 	/**
 	 * Generar un número aleatorio teniendo en cuenta la dirección actual del
@@ -350,7 +350,7 @@ public abstract class BaseNumericalExerciseFragment extends
 	/**
 	 * Debe retornar una cadena con la solución
 	 */
-	protected abstract String getSolution();
+	protected abstract String obtainSolution();
 
 	/**
 	 * Debe retornar true si la solución es correcta

--- a/src/es/uniovi/imovil/fcrtrainer/BinaryExerciseFragment.java
+++ b/src/es/uniovi/imovil/fcrtrainer/BinaryExerciseFragment.java
@@ -67,7 +67,7 @@ public class BinaryExerciseFragment extends BaseNumericalExerciseFragment {
 	}
 
 	@Override
-	protected int getExerciseId() {
+	protected int obtainExerciseId() {
 		return R.string.binary;
 	}
 
@@ -77,7 +77,7 @@ public class BinaryExerciseFragment extends BaseNumericalExerciseFragment {
 	}
 
 	@Override
-	protected String getTitleString() {
+	protected String titleString() {
 		if (mDirectConversion) {
 			return getResources().getString(R.string.convert_dec_to_bin);
 		} else {
@@ -97,7 +97,7 @@ public class BinaryExerciseFragment extends BaseNumericalExerciseFragment {
 	}
 
 	@Override
-	protected String getSolution() {
+	protected String obtainSolution() {
 		if (mDirectConversion) {
 			return convertToBinary(mNumberToConvert);
 		} else {

--- a/src/es/uniovi/imovil/fcrtrainer/BinaryOffsetExerciseFragment.java
+++ b/src/es/uniovi/imovil/fcrtrainer/BinaryOffsetExerciseFragment.java
@@ -17,7 +17,7 @@ public class BinaryOffsetExerciseFragment extends BaseNumericalExerciseFragment 
 	}
 
 	@Override
-	protected int getExerciseId() {
+	protected int obtainExerciseId() {
 		return R.string.offset_binary;
 	}
 
@@ -27,7 +27,7 @@ public class BinaryOffsetExerciseFragment extends BaseNumericalExerciseFragment 
 	}
 
 	@Override
-	protected String getTitleString() {
+	protected String titleString() {
 		int formatStringId;
 		if (mDirectConversion) {
 			formatStringId = R.string.convert_dec_to_bin_offset;
@@ -55,7 +55,7 @@ public class BinaryOffsetExerciseFragment extends BaseNumericalExerciseFragment 
 	}
 
 	@Override
-	protected String getSolution() {
+	protected String obtainSolution() {
 		return mCorrectAnswer;
 	}
 

--- a/src/es/uniovi/imovil/fcrtrainer/HexadecimalExerciseFragment.java
+++ b/src/es/uniovi/imovil/fcrtrainer/HexadecimalExerciseFragment.java
@@ -34,7 +34,7 @@ public class HexadecimalExerciseFragment extends BaseNumericalExerciseFragment {
 	public HexadecimalExerciseFragment() {
 	}
 
-	protected int getExerciseId() {
+	protected int obtainExerciseId() {
 		return R.string.hexadecimal;
 	}
 
@@ -48,7 +48,7 @@ public class HexadecimalExerciseFragment extends BaseNumericalExerciseFragment {
 	}
 
 	@Override
-	protected String getTitleString() {
+	protected String titleString() {
 		if (mDirectConversion) {
 			return getResources().getString(R.string.convert_bin_to_hex);
 		} else {
@@ -57,7 +57,7 @@ public class HexadecimalExerciseFragment extends BaseNumericalExerciseFragment {
 	}
 
 	@Override
-	protected String getSolution() {
+	protected String obtainSolution() {
 		if (mDirectConversion) {
 			return Integer.toHexString(mNumberToConvert).toUpperCase(Locale.US);
 		} else {
@@ -82,7 +82,7 @@ public class HexadecimalExerciseFragment extends BaseNumericalExerciseFragment {
 
 	@Override
 	protected boolean isCorrect(String answer) {
-		return getSolution().equals(answer.toUpperCase(Locale.US));
+		return obtainSolution().equals(answer.toUpperCase(Locale.US));
 	}
 
 }

--- a/src/es/uniovi/imovil/fcrtrainer/SignedMagnitudeExerciseFragment.java
+++ b/src/es/uniovi/imovil/fcrtrainer/SignedMagnitudeExerciseFragment.java
@@ -37,7 +37,7 @@ public class SignedMagnitudeExerciseFragment extends
 	}
 
 	@Override
-	protected int getExerciseId() {
+	protected int obtainExerciseId() {
 		return R.string.sign_and_magnitude;
 	}
 
@@ -75,7 +75,7 @@ public class SignedMagnitudeExerciseFragment extends
 	}
 
 	@Override
-	protected String getTitleString() {
+	protected String titleString() {
 		int formatStringId;
 		if (mDirectConversion) {
 			formatStringId = R.string.convert_dec_to_sign_and_magnitude;
@@ -87,7 +87,7 @@ public class SignedMagnitudeExerciseFragment extends
 	}
 
 	@Override
-	protected String getSolution() {
+	protected String obtainSolution() {
 		return mCorrectAnswer;
 	}
 

--- a/src/es/uniovi/imovil/fcrtrainer/TwosComplementExerciseFragment.java
+++ b/src/es/uniovi/imovil/fcrtrainer/TwosComplementExerciseFragment.java
@@ -31,7 +31,7 @@ public class TwosComplementExerciseFragment extends
 	}
 
 	@Override
-	protected int getExerciseId() {
+	protected int obtainExerciseId() {
 		return R.string.twoscomplement;
 	}
 
@@ -41,7 +41,7 @@ public class TwosComplementExerciseFragment extends
 	}
 
 	@Override
-	protected String getTitleString() {
+	protected String titleString() {
 		int formatStringId;
 		if (mDirectConversion) {
 			formatStringId = R.string.convert_dec_to_twos_complement;
@@ -68,7 +68,7 @@ public class TwosComplementExerciseFragment extends
 	}
 
 	@Override
-	protected String getSolution() {
+	protected String obtainSolution() {
 		if (mDirectConversion) {
 			return BinaryConverter.binaryToStringWithNbits(mNumberToConvert,
 					mNumberOfBits);
@@ -79,7 +79,7 @@ public class TwosComplementExerciseFragment extends
 
 	@Override
 	protected boolean isCorrect(String answer) {
-		return answer.equals(getSolution());
+		return answer.equals(obtainSolution());
 	}
 
 	@Override


### PR DESCRIPTION
La idea es no utilizar "get" para métodos que no son "getters", es
decir, que no acceden directamente a una variable miembro
